### PR TITLE
1.修改启动readme；2.修改json的readme；3.修改apis的readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@ APIHUB是一款基于 Golang 开发的API调度平台，能够实现基于JSON�
 第一阶段主要是提供微服务网关功能，充分利用了Go协程的高并发性能。   
 未来可以对接低代码平台，大大简化对API调用的管理。
 # [基本概念](https://github.com/jasony62/tms-go-apihub/blob/main/doc/cn/base.md)
-# [启动](https://github.com/jasony62/tms-go-apihub/blob/main/doc/cn/start.md)
-# [apigateway](https://github.com/jasony62/tms-go-apihub/blob/main/doc/cn/apigateway.md)
-# [API列表](https://github.com/jasony62/tms-go-apihub/blob/main/doc/cn/apis.md)
-# [JSON定义](https://github.com/jasony62/tms-go-apihub/blob/main/doc/cn/json.md)
+# [启动和编译](https://github.com/jasony62/tms-go-apihub/blob/main/doc/cn/start.md)
+# [APIG定义和执行](https://github.com/jasony62/tms-go-apihub/blob/main/doc/cn/apigateway.md)
+# [JSON SCHEMA定义](https://github.com/jasony62/tms-go-apihub/blob/main/doc/cn/json.md)
+# [API相关接口](https://github.com/jasony62/tms-go-apihub/blob/main/doc/cn/apis.md)
 # [函数](https://github.com/jasony62/tms-go-apihub/blob/main/doc/cn/function.md)
 # [流程说明](https://github.com/jasony62/tms-go-apihub/blob/main/doc/cn/flow.md)
 # [测试](https://github.com/jasony62/tms-go-apihub/blob/main/doc/cn/test.md)

--- a/doc/cn/apis.md
+++ b/doc/cn/apis.md
@@ -1,27 +1,1039 @@
-支持api列表
-| 名称           | 入参  | 用途     |
-| ------------- | ----- | -------- |
-| 启动相关（用于main.json） |  |  |
-| loadConf | 无 | 从base目录读取conf文件 |
-| confValidator（完善中） | schema（必选） json schema路径 | 对所有json文件进行json和json schema检查 |
-| apiGateway | host（可选，默认0.0.0.0）监听地址；port（可选，默认8080），监听端口；bucket（可选，默认false），是否使用bucket功能；pre（可选，默认_APIGATEWAY_PRE），pre flow json名字，none代表不执行；httpApi（可选，默认_APIGATEWAY_HTTPAPI），执行httpapi的flow json名字；postOK（可选，默认_APIGATEWAY_POST_OK），POST OK的flow json名字，none代表不执行；postNOK（可选，默认_APIGATEWAY_POST_NOK），POST NOK的flow json名字，none代表不执行| 启动apigateway，注意这个api不会返回 |
-| downloadConf | url（必选）  远端文件地址 | 从远端服务器下载conf文件 |
-| decompressZip | file（必选） 需要解压的文件名称，通常与downloadConf这个中url中的文件名一致，均为.zip格式；<br />password（可选） 解压密码<br />path（可选） 解压之后的存储目录，不配则使用base目录 | 解压远端下载后的zip压缩包 |
-| 执行json文件 |  |  |
-| httpApi | name httpapi名字，private（可选）秘钥文件名称| 执行httpapi，发送http请求 |
-| flowApi | name flow名字，private（可选）秘钥文件名称| 执行flow |
-| scheduleApi | name schedule名字，private（可选）秘钥文件名称| 执行schedule |
-| http相关 |  |  |
-| httpResponse | type（json，html，或者其他） http response名称，key，从哪个result获取，type为json时转换为string，其他则直接按照string发送 code, 发送的HTTP code，不输入则为200| 在使用httpapi时，默认发送json格式的HTTP rsponse，flow和schedule没有这个默认逻辑，必须调用这个API发送http response|
-| 辅助类 |  |  |
-| checkStringsEqual | 任意| 检查数组中所有name和value是否都相等，用于解决200 OK+ error 在response json里的问题，参考例子{"name": "0","value": {"from": "heap","content": "sendResult.errcode"}} |
-| checkStringsNotEqual | 任意| 检查数组中所有name和value是否都不相等，用于检查http回应内的值是否有效，参考例子        {"name": "","value": {"from": "heap","content": "tokenResult.access_token"}} |
-| createJson | key origin入参中的name| 创建一个新的json结构体，并且存放在resultKey |
-| createHtml | type（local则从content中获取，resource则从resource目录获取），content html内容或者resource文件名| 生成html页面，并且存放在resultKey |
-| setDefaultAccessRight | default（可选） 设置默认执行权限，默认“access”，如果设置为“deny”，则拒绝访问 | 默认执行权限 |
-| checkRight | userKey 查询参数中的用户id关键字； name httpapi名字；type 是httpapi，flow，schedule | 检查是否具有运行权限 |
-| storageStore | user 查询用户appID，可以配置在query中，也可以在header中；key origin入参中的name；index 需要存储的索引关键字； source 存储方式 “local”-本地结构存储；content 存储的内容， 如果是“json”，则需要存储origin中的数据，如果为其他，则直接存储 | 多租户支持，存储某用户的数据，后面用来获取 |
-| storageLoad | index 需要读取的索引关键字； source 存储方式 “local”-本地结构存储；content 读取的内容， 如果是“json”，则需要将读取到内容解析为json，如果为其他，则直接返回 | 多租户支持，读取某用户之前存储的数据，用来回复相关用户 |
-| promStart | host（可选，默认0.0.0.0）监听地址，port（可选，默认8000），监听端口| 启动prometheus服务并注册counter和histogram |
-| promHttpCounterInc | httpInOut（填"httpIn"或者"httpOut"）设置httpin或者httpout类型的统计，其他参数均是供prometheus统计的label | 增加prometheus counter和histogram的统计 |
 
+# 前言
+
+本设计通过API编排的方式实现了对API的调用，同时API编排实现了低代码的方式实现。
+
+本设计中低代码实现方式体现在API网关程序与API配置信息解耦。
+
+若要实现API编排，仅需通过程序规范好的JSON文件格式进行编排即可，不涉及具体功能实现，上述过程即本设计的低代码实现方式。
+
+本章节主要聚焦API编排过程中，在低代码方式编写JSON文件时所需的API说明，体现在API功能介绍、源码位置、输入参数说明、状态码说明，帮助使用者快速上手编排。
+
+API列表如下：
+
+表1：启动相关API
+
+| API名称 | 功能简述 |
+| -- | -- |
+| welcome | 启动界面 |
+| confValidator | json schema检查 |
+| loadConf |  加载Conf文件 |
+| apiGateway | API网关启动 |
+| downloadConf  | 远端Conf下载 |
+| decompressZip | 解压远端压缩包 |
+
+表2：执行相关API
+
+| API名称 | 功能简述 |
+| -- | -- |
+| httpApi  | HTTP请求 |
+| httpResponse  | HTTP返回结果 |
+| flowApi  | FLOW请求 |
+| scheduleApi | SCHEDULE请求 |
+| createJson  | 创建json结构体 |
+| createHtml  | 创建html |
+
+表3：辅助功能API
+
+| API名称 | 功能简述 |
+| -- | -- |
+| checkStringsEqual  | 检查name、value是否相等 |
+| checkStringsNotEqual  | 检查name、value是否不相等 |
+| storageStore  | 存储数据 |
+| storageLoad  | 加载存储数据 |
+| setDefaultAccessRight  | 默认执行权限 |
+| checkRight  | 检查权限 |
+
+表4：普罗米修斯相关API
+| API名称 | 功能简述 |
+| -- | -- |
+| promStart | 普罗米修斯启动 |
+| promHttpCounterInc  | 普罗米修斯http统计 |
+# 启动相关API
+
+程序调用`API`既有外部`API`也有内部`API`，但无所谓内外，对于`command`名称调用的API都是指向的一个`API`，仅仅是地址不同。
+
+首先对json文件中名称进行介绍，如json.md所示。
+
+`main.json`中各启动对象均已API形式进行调用，例如：
+```
+{
+  "name": "main",
+  "description": "main for apigateway",
+  "steps": [
+    {
+      "name": "welcome",
+      "command": "welcome",
+      "description": "welcome",
+      "args": [
+        {
+          "name": "content",
+          "value": {
+            "from": "literal",
+            "content": "welcome to use apihub"
+          }
+        }
+      ]
+    },
+    ... ...
+    ... ...
+}
+```
+* `"name": "welcome"`，表示当前对象名称；
+
+* `"command": "welcome"`，表示当前对象调用叫做`welcome`的API接口；
+
+* `"args": [{"name": "content","value": {"from": "literal","content": "welcome to use apihub"}}`，表示将`args`关键字的`json`数组内容并发的输入到内部的`welcome API`接口。
+
+## 1. 启动界面（welcome API）
+### 1.1. 功能介绍
+apihub程序启动后，首次调用conf配置文件夹时，屏幕打印输`出welcome to use apihub`字符串，用于提示用户程序开始读取conf文件夹API配置信息。
+### 1.2. 位置
+```
+./broker/main.go/
+```
+### 1.3. API输入介绍
+`welcome API` 输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| "content" | 可选 | literal | 输出字符串 | 输出打印字符串`"welcome to use apihub"` ` |
+
+
+示例：
+```
+{
+    "name": "welcome",
+    "command": "welcome",
+    "description": "welcome",
+    "args": [
+      {
+        "name": "content",
+        "value": {
+          "from": "literal",
+          "content": "welcome to use apihub"
+        }
+      }
+    ]
+}
+```
+### 1.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+## 2. schema检查（confValidator API）（完善中）
+### 2.1 功能介绍
+对所有需要导入的json文件进行json和json schema检查
+### 2.2. 位置
+```
+./broker/apis/schema.go
+```
+### 2.3. API输入介绍
+`confValidator API` 输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| "schem" | 必选 | literal | Path | json schema文件夹路径，默认代码库主目录位置。即"../schema" |
+
+
+示例：
+```
+{
+    "name": "confValidator",
+    "command": "confValidator",
+    "description": "confValidator",
+    "args": [
+      {
+        "name": "schema",
+        "value": {
+          "from": "literal",
+          "content": "../schema"
+        }
+      }
+    ]
+}
+```
+### 2.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+## 3. 加载Conf文件（loadConf API）
+### 3.1. 功能介绍
+从`--base`指定目录读取conf文件
+### 3.2. 位置
+```
+./broker/apis/util.go
+```
+### 3.3. API输入介绍
+`loadConf API`输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| 无 | 必选 | 无 | 无 | 无 |
+
+示例：
+```
+{
+  "name": "loadConf",
+  "command": "loadConf",
+  "description": "loadConf"
+}
+```
+### 3.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+
+
+
+## 4. API网关启动（apiGateway API）（完善中）
+### 4.1. 功能介绍
+启动`apigateway API`，注意这个api不会返回
+### 4.2. 位置
+```
+./broker/apis/apigateway.go
+```
+### 4.3. API输入介绍
+`apiGateway API`输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| "host" | 可选 | literal | 0.0.0.0 ~ 255.255.255.255 | 监听地址默认0.0.0.0 |
+| "port" | 可选 | literal | 1024 ~ 65535 | 监听端口默认8080 |
+| "bucket“ | 可选 | literal | "true";</br>"false"; | 默认false，是否使用bucket功能 |
+| "pre" | 可选 | literal | "APIGATEWAY_PRE";</br>"none";</br>"JSON名称"; | 默认_APIGATEWAY_PRE，pre flow json名字，none代表不执行 |
+| "httpApi" | 可选 | literal |" _APIGATEWAY_HTTPAPI";</br>"none";</br>"JSON名称"; | 默认_APIGATEWAY_HTTPAPI，执行httpapi的flow json脚本的名字 |
+| "postOK" | 可选 | literal | "_APIGATEWAY_POST_OK";</br>"none";</br>J"JSON名称"; | 默认_APIGATEWAY_POST_OK，POST OK的flow json名字，none代表不执行 |
+| "postNOK" | 可选 | literal | "_APIGATEWAY_POST_NOK";</br>"none";</br>"JSON名称"; | 默认_APIGATEWAY_POST_NOK，POST NOK的flow json名字，none代表不执行 |
+
+
+示例：
+```
+{
+  "name": "apiGateway",
+  "command": "apiGateway",
+  "description": "apiGateway",
+  "args": [
+    {
+      "name": "host",
+      "value": {
+        "from": "literal",
+        "content": "0.0.0.0"
+      }
+    },
+    {
+      "name": "port",
+      "value": {
+        "from": "literal",
+        "content": "8080"
+      }
+    }
+  ]
+}
+```
+### 4.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+
+## 5. 远端Conf下载（downloadConf API）（未上线）
+### 5.1. 功能介绍
+若本地无响应conf文件，可通过配置从远端服务器下载conf文件
+### 5.2. 位置
+无
+### 5.3. API输入介绍
+`downloadConf API`输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| url | 必选 | literal | Addr | 远端Conf文件地址 | 
+### 5.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+
+## 6. 解压远端压缩包（decompressZip）（未上线）
+### 6.1. 功能介绍
+若下载远端文件为压缩包，解压远端下载后的zip压缩包。
+### 6.2. 位置
+无
+### 6.3. API输入介绍
+
+`decompressZip API`输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| file | 必选 | literal | 解压文件名 | 需要解压的文件名称，通常与downloadConf这个中url中的文件名一致，均为.zip格式 | 
+| password | 可选 | literal | 密码字符串 | 解压密码 | 
+| path | 可选 | literal | "Path" | 默认使用`--base`目录，解压之后的存储目录 |
+### 6.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+
+# 执行json文件
+## 1. HTTP请求（httpApi API）
+### 1.1. 功能介绍
+执行httpApi，发送http请求，执行一个API调用。
+### 1.2. 位置
+```
+./broker/apis/httpapi.go
+```
+### 1.3. API输入介绍
+`httpApi API`输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| "name" | 必选 | literal | "httpapi文件名" | httpapi名称，详见./example/httpapis/*.json，例如"amap_district"，指向amap_district.json文件 |
+| internal | 可选 | literal | "true";</br>"false"; | 判断是否为内部API |
+| private | 可选 | literal | "密钥文件名" | httpapi密钥文件名称 |
+
+示例：
+```
+{
+   "name": "city_adcode",
+   "command": "httpApi",
+   "description": "查询城市的区域码",
+   "args": [
+     {
+       "name": "name",
+       "value": {
+         "from": "literal",
+         "content": "amap_district"
+       }
+     }
+   ],
+   "resultKey": "adcodeResult"
+},
+```
+### 1.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+## 2. HTTP返回结果（httpResponse API）
+### 2.1. 功能介绍
+在使用httpapi时，默认发送json格式的HTTP rsponse，使用flowapi和scheduleapi没有这个默认逻辑，必须调用这个API发送http response。
+### 2.2. 位置
+```
+./broker/apis/http.go
+```
+### 2.3. API输入介绍
+`httpResponse API`输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| "type" | 可选 | literal | "json";</br>"html";</br>"其他"; | http response名称 |
+| "key" | 可选 | literal | "NOK_result";</br>"httpapi_result";</br>"merge_result";</br>"..." | 上文"resultKey"获取，type为json时key转换为String，其他则直接按照string发送 |
+| code | 可选 | template | {{ .resultKey.code }} | 上文resultKey.code获取，例如：{{.NOK_result.code}}，生成template内容， 发送的HTTP code，不输入默认200 |
+
+示例：
+```
+{
+  "name": "response",
+  "command": "httpResponse",
+  "description": "返回结果",
+  "args": [
+    {
+      "name": "type",
+      "value": {
+        "from": "literal",
+        "content": "json"
+      }
+    },
+    {
+      "name": "key",
+      "value": {
+        "from": "literal",
+        "content": "NOK_result"
+      }
+    },
+    {
+      "name": "code",
+      "value": {
+        "from": "template",
+        "content": "{{.NOK_result.code}}"
+      }
+    }
+  ]
+}
+```
+
+### 2.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+## 3. FLOW（flowApi API）
+### 3.1. 功能介绍
+执行flowApi，发送flow请求，执行一个调用流程，即编排流程。
+### 3.2 位置
+```
+./broker/core/flow.go
+```
+### 3.3. API输入介绍
+`flowApi API`输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| "name" | 必选 | literal | "flow文件名" | flow名称，详见./example/flows/*.json，例如"amap_city_weather_base"，指向amap_city_weather_base.json文件 |
+| internal | 可选 | literal | "true";</br>"false"; | 判断是否为内部API |
+| private | 可选 | literal | "密钥文件名" | flowapi密钥文件名称 |
+
+示例：
+```
+{
+  "name": "city_adcode",
+  "command": "flowApi",
+  "description": "查询城市天气",
+  "args": [
+    {
+      "name": "name",
+      "value": {
+        "from": "literal",
+        "content": "amap_city_weather_base"
+      }
+    }
+  ],
+  "resultKey": "weatherResult"
+},
+```
+### 3.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+## 4. SCHEDULE（scheduleApi API）
+### 4.1. 功能介绍
+
+执行schedule，发送schedule请求，执行一个计划流程。
+
+### 4.2. 位置
+```
+./broker/core/schedule.go
+```
+### 4.3. API输入介绍
+`scheduleApi API`输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| "name" | 必选 | literal | "schedule文件名" | scheduleApi名称，详见./example/schedules/*.json |
+| private | 可选  | literal | "密钥文件名" | schedule密钥文件名称 |
+
+示例：
+```
+
+```
+### 4.4. 状态码 
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+
+## 5. 创建json结构体（createJson API）
+### 5.1. 功能介绍
+创建一个新的json结构体，并且存放在resultKey。
+### 5.2. 位置
+```
+./broker/apis/json.go
+```
+### 5.3. API输入介绍
+`createJson API`输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| "key" | 必选 | literal | "merge_result";</br>任意; | 后文origin的name名称 |
+
+`createJson API`输入数组`origin`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| "上文content内容" | 必选 | jsonRaw | json内容 | 根据json内容生成json结构体 |
+
+示例：
+```
+{
+  "name": "merge_result",
+  "command": "createJson",
+  "description": "合并收到的结果",
+  "resultKey": "merged",
+  "args": [
+    {
+      "name": "key",
+      "value": {
+        "from": "literal",
+        "content": "merge_result"
+      }
+    }
+  ],
+  "origin": [
+    {
+      "name": "merge_result",
+      "value": {
+        "from": "jsonRaw",
+        "json": {
+          "errCode": "{{.weatherResult.status}}",
+          "data": {
+            "region": "{{(index .weatherResult.lives 0).province}}",
+            "weather": "{{(index .weatherResult.lives 0).weather}}",
+            "temperature": "{{(index .weatherResult.lives 0).temperature}}",
+            "winddirection": "{{(index .weatherResult.lives 0).winddirection}}",
+            "windpower": "{{(index .weatherResult.lives 0).windpower}}",
+            "humidity": "{{(index .weatherResult.lives 0).humidity}}"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+### 5.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+
+
+## 6. 创建html（createHtml API）
+### 6.1. 功能介绍
+生成html页面，并且存放在resultKey。
+### 6.2. 位置
+```
+./broker/apis/html.go
+```
+### 6.3. API输入介绍
+`createHtml API`输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| "type" | 必选 | literal | "local";</br>"resource" | local表示从content中获取;</br>resource表示从resource目录获取; |
+| "content" | 必选 | literal | html内容或者resource文件名 |
+
+
+示例：
+```
+{
+  "name": "merge_result",
+  "command": "createHtml",
+  "description": "创建html",
+  "resultKey": "mergedHtml",
+  "args": [
+    {
+      "name": "type",
+      "value": {
+        "from": "literal",
+        "content": "local"
+      }
+    },
+    {
+      "name": "content",
+      "value": {
+        "from": "literal",
+        "content": "<html><head><title>Hello API</title></head><body><p>status:{{.weatherResult.status}}</p><p>region:{{(index .weatherResult.lives 0).province}}</p><p>weather:{{(index .weatherResult.lives 0).weather}}</p><p>temperature:{{(index .weatherResult.lives 0).temperature}}</p><p>winddirection:{{(index .weatherResult.lives 0).winddirection}}</p><p>windpower:{{(index .weatherResult.lives 0).windpower}}</p><p>humidity:{{(index .weatherResult.lives 0).humidity}}</p></body></html>"
+      }
+    }
+  ]
+},
+```
+### 6.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+
+
+
+
+
+# 辅助功能API
+## 1. 检查name、value是否相等（checkStringsEqual API）
+### 1.1. 功能介绍
+检查数组中所有name和value是否都相等，用于解决200 OK + error 在response json里的问题
+### 1.2. 位置
+```
+./broker/api/string.go
+```
+### 1.3. API输入介绍
+`checkStringsEqual API`输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| "0";</br>"任意" | 必选 | -- | "sendResult.errcode";</br>"任意" | 检查数组中所有name和value是否都相等，例如"name":"0"，与本json文件上文resultKey获取的sendResult.errcode对比，若sendResult.errcode与"0"相等，则API调用成功 |
+
+示例：
+```
+{
+  ... ...
+  ... ...
+  "resultKey": "sendResult"
+},    
+{
+  "name": "checkResult",
+  "description": "检查返回值",
+  "command": "checkStringsEqual",
+  "args": [
+    {
+      "name": "0",
+      "value": {
+        "from": "heap",
+        "content": "sendResult.errcode"
+      }
+    }
+  ]
+}
+```
+### 1.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+
+## 2. 检查name、value是否不相等（checkStringsNotEqual API）
+### 2.1. 功能介绍
+检查数组中所有name和value是否都不相等，用于检查http回应内的值是否有效。
+### 2.2. 位置
+```
+./broker/api/string.go
+```
+### 2.3. API输入介绍
+`checkStringsNotEqual API`输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| "";</br>"任意" | 可选 | heap | "tokenResult.access_token";</br>"任意" | 检查数组中所有name和value是否不相等，例如"name":""，与本json文件上文resultKey获取的tokenResult.access_token对比，若tokenResult.access_token不为""，则API返回的token有值，即token获取成功 |
+
+示例： 
+```
+{
+  ... ...
+  ... ...
+  "args": [
+    {
+      ... ...
+      }
+    }
+  ],
+  "resultKey": "tokenResult"
+},
+{
+  "name": "checkTokenResult",
+  "description": "检查token是否有效",
+  "command": "checkStringsNotEqual",
+  "args": [
+    {
+      "name": "",
+      "value": {
+        "from": "heap",
+        "content": "tokenResult.access_token"
+      }
+    }
+  ]
+}
+```
+### 2.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+
+
+## 3. 存储数据（storageStore API）
+### 3.1. 功能介绍
+引入storage层，负责存储和加载，引入两个API storageStore，storageLoad，本小结介绍storageStore API。
+
+多租户支持，存储某用户的数据，后面用来获取。
+### 3.2. 位置
+```
+./broker/apis/storage.go
+```
+### 3.3. API输入介绍
+`storageStore API`输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| "user" | 可选 | query | "appID" | 用户ID关键字，可以配置在query或header中，即"from": "query"，或"from": "header" |
+| "key" | 可选 | literal | "任意" | 索引key，后文origin输入参数中的name |
+| "index" | 可选 | template | {{}} | 需要存储的索引关键字，template规范的索引关键字 |
+| "source" | 可选 | literal | "local";</br>"mongodb"; | 存储方式 :</br>“local”-本地结构存储;</br>"mongodb"-远程数据库存储 |
+| "content" | 可选 | template | "json";</br>"...";  | 存储的内容，如果是“json”，则需要存储origin中的数据；如果为其他，则直接存储 |
+
+`storageStore API`输入`origin`参数介绍
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| "上文content内容" | 必选 | jsonRaw | json内容 | 根据json内容生成json结构体 |
+
+示例：
+```
+{
+  "name": "storage_store",
+  "command": "storageStore",
+  "description": "保存查询到的城市码",
+  "args": [
+    {
+      "name": "user",
+      "value": {
+        "from": "query",
+        "content": "appID"
+      }
+    },
+    {
+      "name": "key",
+      "value": {
+        "from": "literal",
+        "content": "store_result"
+      }
+    },
+    {
+      "name": "index",
+      "value": {
+        "from": "template",
+        "content": "{{(index .adcodeResult.districts 0).adcode}}"
+      }
+    },
+    {
+      "name": "source",
+      "value": {
+        "from": "literal",
+        "content": "local"
+      }
+    },
+    {
+      "name": "content",
+      "value": {
+        "from": "template",
+        "content": "json"
+      }
+    }
+  ],
+  "origin": [
+    {
+      "name": "store_result",
+      "value": {
+        "from": "jsonRaw",
+        "json": {
+          "errCode": "{{.weatherResult.status}}",
+          "data": {
+            "region": "{{(index .weatherResult.lives 0).province}}",
+            "weather": "{{(index .weatherResult.lives 0).weather}}",
+            "temperature": "{{(index .weatherResult.lives 0).temperature}}",
+            "winddirection": "{{(index .weatherResult.lives 0).winddirection}}",
+            "windpower": "{{(index .weatherResult.lives 0).windpower}}",
+            "humidity": "{{(index .weatherResult.lives 0).humidity}}"
+          }
+        }
+      }
+    }
+  ],      
+  "resultKey": "storaged"
+},
+```
+### 4.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+
+## 5. 加载存储数据（storageLoad API）
+### 5.1. 功能介绍
+多租户支持，读取某用户之前存储的数据，用来回复相关用户。
+### 5.2. 位置
+```
+./broker/apis/storage.go
+```
+### 5.3. API输入介绍
+`storageLoad API`输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| "key" | 可选 | literal | "任意" | 索引key |
+| "index" | 可选 | template | {{}} | 需要读取的索引关键字，template规范的索引关键字 |
+| "source" | 可选 | literal | "local";</br>"mongodb"; | 存储方式 :</br>“local”-本地结构存储;</br>"mongodb"-远程数据库存储 |
+| "content" | 可选 | template | {{}} | 读取的内容，如果是“json”，则需要将读取到内容解析为json；如果为其他，则直接返回 |
+
+
+示例：
+```
+{
+  "name": "storage_load",
+  "command": "storageLoad",
+  "description": "查询城市码",
+  "args": [
+    {
+      "name": "key",
+      "value": {
+        "from": "literal",
+        "content": "load_result"
+      }
+    },
+    {
+      "name": "index",
+      "value": {
+        "from": "template",
+        "content": "{{(index .adcodeResult.districts 0).adcode}}"
+      }
+    },
+    {
+      "name": "source",
+      "value": {
+        "from": "literal",
+        "content": "local"
+      }
+    },
+    {
+      "name": "content",
+      "value": {
+        "from": "template",
+        "content": "json"
+      }
+    }
+  ],     
+  "resultKey": "loaded"
+},
+```
+### 5.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+
+## 6. 默认执行权限（setDefaultAccessRight API）
+### 6.1. 功能介绍
+设置默认执行权限。
+### 6.2. 位置
+```
+./broker/apis/right.go
+```
+### 6.3. API输入介绍
+`setDefaultAccessRight API`输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| "default" | 可选 | literal | "access";</br>"deny"; | 设置默认执行权限，默认“access”，如果设置为“deny”，则拒绝访问 |
+
+示例：
+```
+```
+### 6.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+
+## 7. 检查权限（checkRight API）
+### 7.1. 功能介绍
+检查是否具有运行权限。
+### 7.2. 位置
+```
+./broker/apis/right.go
+```
+### 7.3. API输入介绍
+`checkRight API`输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| "user" | 可选 | literal | "appID" | 查询参数中的用户id关键字 |
+| "name" | 可选 | template |  {{.*.*}} | template规范的httpapi，flow，schedule名 |
+| "type" | 可选 | literal | {{.*.*}} | type 是httpapi，flow，schedule |
+
+示例：
+```
+{
+  "name": "check_right",
+  "command": "checkRight",
+  "description": "查询执行权限",
+  "args": [
+    {
+      "name": "user",
+      "value": {
+        "from": "query",
+        "content": "appID"
+      }
+    },
+    {
+      "name": "name",
+      "value": {
+        "from": "template",
+        "content": "{{.base.root}}"
+      }
+    },
+    {
+      "name": "type",
+      "value": {
+        "from": "literal",
+        "content": "{{.base.type}}"
+      }
+    }
+  ]
+}
+```
+### 7.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+# 普罗米修斯相关API
+
+## 1. 普罗米修斯启动（promStart API）
+### 1.1. 功能介绍
+启动prometheus（普罗米修斯）服务并注册`counter`和`histogram`。
+### 1.2. 位置
+```
+./broker/apis/prometheus.go
+```
+### 1.3. API输入介绍
+`promStart API`输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- | 
+| promHost | 可选 | literal | 0.0.0.0 ~ 255.255.255.255 | prometheus默认监听地址0.0.0.0 |
+| promPort | 可选 | literal | 1024 ~ 65535 | prometheus默认监听端口8000 |
+
+
+示例：
+```
+{
+  "name": "promStart",
+  "command": "promStart",
+  "description": "promStart",
+  "args": [
+    {
+      "name": "promHost",
+      "value": {
+        "from": "literal",
+        "content": "0.0.0.0"
+      }
+    },
+    {
+      "name": "promPort",
+      "value": {
+        "from": "literal",
+        "content": "8000"
+      }
+    }
+  ]
+}
+```
+### 1.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |
+## 2. 普罗米修斯http统计（promHttpCounterInc API）
+### 2.1. 功能介绍
+增加prometheus counter和histogram的统计。
+
+当前在下面四个FLOW里面增加统计
+* _APIGATEWAY_POST_OK.json
+* _APIGATEWAY_POST_NOK.json
+* _HTTPOK.json
+* _HTTPNOK.json
+### 2.2. 位置
+```
+./broker/apis/prometheus.go
+```
+### 2.3. API输入介绍
+`promHttpCounterInc API`输入数组`args`参数介绍：
+| 输入name | 是否必选 | 参数位置 | value内容 | 描述 |
+| -- | -- | -- | -- | -- |
+| "httpInOut" | 可选 | literal | "httpIn";</br>"httpOut"; | 设置httpin或者httpout类型的统计，apigateway进入或出去的请求数目 |
+| "duration" | 可选 | template | {{}} | http_in_duration_sec:apigateway进入的请求处理时间，0-10秒，每秒一个桶; </br>http_out_duration_sec:apigateway出去的请求处理时间，0-10秒，每秒一个桶；|
+| "root";</br>"start";</br>"type";</br>"uuid";</br>"type";</br>"child";</br>"code";</br>"id";</br>"msg";</br>... ...| 可选 | literal | -- | prometheus统计的label：</br>type：apigateway入请求的类型，可以为httpapi，flow，schedule；</br>root：apigateway入请求的名称；</br>child：对外调用的httpapi的名称；</br>code：返回的HTTP回应code；|
+
+示例：
+```
+{
+  "name": "promHttp_In_CounterInc",
+  "command": "promHttpCounterInc",
+  "description": "promHttp_In_CounterInc",
+  "args": [
+    {
+      "name": "httpInOut",
+      "value": {
+        "from": "literal",
+        "content": "httpIn"
+      }
+    },
+    {
+      "name": "root",
+      "value": {
+        "from": "template",
+        "content": "{{.base.root}}"
+      }
+    },
+    {
+      "name": "start",
+      "value": {
+        "from": "template",
+        "content": "{{.base.start}}"
+      }
+    },
+    {
+      "name": "type",
+      "value": {
+        "from": "template",
+        "content": "{{.base.type}}"
+      }
+    },
+    {
+      "name": "uuid",
+      "value": {
+        "from": "template",
+        "content": "{{.base.uuid}}"
+      }
+    },
+    {
+      "name": "type",
+      "value": {
+        "from": "template",
+        "content": "{{.base.type}}"
+      }
+    },
+    {
+      "name": "child",
+      "value": {
+        "from": "template",
+        "content": "{{.stats.child}}"
+      }
+    },
+    {
+      "name": "code",
+      "value": {
+        "from": "template",
+        "content": "{{.stats.code}}"
+      }
+    },
+    {
+      "name": "duration",
+      "value": {
+        "from": "template",
+        "content": "{{.stats.duration}}"
+      }
+    },
+    {
+      "name": "id",
+      "value": {
+        "from": "template",
+        "content": "{{.stats.id}}"
+      }
+    },
+    {
+      "name": "msg",
+      "value": {
+        "from": "template",
+        "content": "{{.stats.msg}}"
+      }
+    }
+  ]
+}
+```
+### 2.4. 状态码
+| 状态码 | 描述 |
+| -- | -- |
+| 200 | StatusOK，获取信息成功 |
+| 403 | StatusForbidden，获取信息失败 |
+| 500 | StatusInternalServerError，获取信息失败 |

--- a/doc/cn/json.md
+++ b/doc/cn/json.md
@@ -1,102 +1,105 @@
 # 基础结构
+
 value和param是两个基础结构，用在多处。
-value定义为
-| 字段           | 用途  | 类型     | 必选 |
-| ------------- | ----- | -------- | ---- |
-| from      | 获取参数值的位置,支持`literal`(直接从content里获取)，`query`(http query),`header`(http header),`private`(从秘钥文件读取),`origin`(原始报文body中的json),"env"(系统env)，heap(从原始报文和处理结果获取)，json(根据json生成字符串)，jsonRaw(根据json生成json结构体)，template(从content中生成),`func`(hub.FuncMap内部定义函数的名称)。               |     string     |  是    |
-| content      | 参数名称，或者函数名称，或者template的内容。                 |     string     | 否     |
-| args      | from为func时，func的输入参数，多个参数时需要以空格分割，如："args": "apikey X-CurTime X-Param"                 | string         |   否   |
-| json  | json的输入值,支持.origin.访问输入json，.vars.访问在parameters定义的值，支持采用template的FuncMap的方式直接调用hub.FuncMapForTemplate内部定义的函数(例如"template": "{{md5 .vars.apikey .vars.XCurTime .vars.XParam}}")。如果入参名字含有字符-，则需要定义一个新的vars，去掉原名字中的-|    object      |  否    |
-param定义为
-| 字段           | 用途  | 类型     | 必选 |
-| ------------- | ----- | -------- | ---- |
-| name      | 变量名称               |     string     |  是    |
-| value    | 值，value结构体。    | object   | 是   |
+
+value定义为:
+
+| 字段名称 | 是否必选 | 数据类型 | 描述 | 
+| -- | -- | -- | -- | 
+| from |  必选 | String | 获取参数值的位置,支持:</br>`literal`(直接从content里获取);</br>`query`(http query);</br>`header`(http header);</br>`private`(从秘钥文件读取);</br>`origin`(原始报文body中的json);</br>`env`(系统env);</br>`heap`(从原始报文和处理结果获取);</br>`json`(根据json生成字符串);</br>`jsonRaw`(根据json生成json结构体);</br>`template`(从content中生成);</br>`func`(hub.FuncMap内部定义函数的名称)。 |
+| content | 可选 | String | 参数名称，或者函数名称，或者template的内容。|
+| args | 可选 | String | from为func时，func的输入参数，多个参数时需要以空格分割，如："args": "apikey X-CurTime X-Param"。 |
+| json | 可选 | String | json的输入值,支持`.origin.`访问输入json，.vars.访问在parameters定义的值，支持采用template的FuncMap的方式直接调用hub.FuncMapForTemplate内部定义的函数(例如"template": "{{md5 .vars.apikey .vars.XCurTime .vars.XParam}}")。如果入参名字含有字符-，则需要定义一个新的vars，去掉原名字中的-。 |
+
+param定义为:
+
+| 字段名称 | 是否必选 | 数据类型 | 描述 | 
+| -- | -- | -- | -- |
+| name | 必选 | String |  变量名称    |
+| value | 必选 | Object | 值，value结构体 |
 # PRIVATE
 private用于存储秘钥类信息，和API相对独立，不同部署，值会发生变化。
-| 字段           | 用途| 类型     | 必选 |
-| -------------- | ------------- | -------- | ---- |
-| name           | private名称称。                                                                                                                       | string   | 是   |
-| value    | private值。                                                                                                                       | string   | 是   |
+
+| 字段名称 | 是否必选 | 数据类型 | 描述 |  
+| -- | -- | -- | -- |
+| name | 必选 | String | private名称称。|                                                  
+| value | 必选 | String | private值。|
 # HTTPAPI
 建议所有需要从template，func中传入的参数，都独立定义在parameter中，并使用origin。
 
-| 字段          | 用途 | 类型     | 必选 |
-| -------------- | ------------- | ----- | ---- |
-| id            | HTTPAPI，而是根据指定 定义的标识。  | string   | 是   |
-| url           | HTTPAPI，而是根据指定 的目标地址。不包括任何查询参数。 | string   | 否   |
-| dynamicUrl    | 当url为空时，必须提供这个结构，用来动态生成URL（比如路径中含有appId），结构为标准的value结构。    | object   | 否   |
-| private       | HTTPAPI，而是根据指定 秘钥文件名。| string   | 否   |
-| description   | HTTPAPI，而是根据指定 的描述。 | string   |  否    |
-| method        | HTTP 请求方法，支持`POST`和`GET`。                                                                    | string   | 是   |
-|requestContentType | json映射为`application/json`，form映射为`application/x-www-form-urlencoded`，origin为取输入报文的ContentType，并直接转发输入报文的http body，none表示没有body,其他值则直接写入ContentType|string |是|
-|  |  |  |  |
-| args    | HTTP 请求的参数。                                                                                     | object[] |    否  |
-| --in          | 参数位置。支持`query`，`header`,`body`, `vars`。前三者的值除了会放到发送报文里，还可以在模板通过.vars.访问，vars表示只进入.vars| string| 是   |
-| --name        | 参数名称。 | string   | 是   |
-| --value        | 参数值，标准value结构。          | object   | 是   |  |  |  |  |
-| cache | HTTP请求是否支持缓存模式，如果支持，在过期时间内，将不会再向服务器请求，而是直接返回缓存内容。 | object | 否 |
-| --format | 指定过期时间的解析格式。分为秒“second”和具体时间格式，如：“20060102150405” | string | 是 |
-| --expire | 指定过期时间的获取位置，标准value结构。 | object | 是 |
-| ----from | 差异：获取过期时间的位置，是从header域中获取的话，则设置为“header”，如果从body中获取，则设置为“template” | string | 是 |
-|          |                                        |        |    |
+| 字段名称 | 是否必选 | 数据类型 | 描述 | 
+| -- | -- | -- | -- |
+| id | 必选 | String | HTTPAPI，而是根据指定 定义的标识。 |
+| url | 可选 | String | HTTPAPI，而是根据指定 的目标地址。不包括任何查询参数。 |
+| dynamicUrl | 可选 | Object |  当url为空时，必须提供这个结构，用来动态生成URL（比如路径中含有appId），结构为标准的value结构。 |
+| private | 可选 | String | HTTPAPI，而是根据指定 秘钥文件名。| 
+| description | 可选 | String | HTTPAPI，而是根据指定 的描述。 |
+| method | 必选 | String | HTTP 请求方法，支持`POST`和`GET`。 |
+| requestContentType | 必选 | String | json映射为`application/json`，form映射为`application/x-www-form-urlencoded`，origin为取输入报文的ContentType，并直接转发输入报文的http body，none表示没有body,其他值则直接写入ContentType|
+| args | 可选 | Object[] |  HTTP 请求的参数。 |
+| &nbsp; &nbsp; &nbsp; &nbsp;-- in | 必选 | String | 参数位置。支持:</br>`query`;</br>`header`;</br>`body`;</br> `vars`。</br>前三者的值除了会放到发送报文里，还可以在模板通过.vars.访问，vars表示只进入.vars|
+| &nbsp; &nbsp; &nbsp; &nbsp;-- name | 必选 | String | 参数名称。 | 
+| &nbsp; &nbsp; &nbsp; &nbsp;-- value | 必选 | Object | 参数值，标准value结构。 |
+| cache | 可选 | Object | HTTP请求是否支持缓存模式，如果支持，在过期时间内，将不会再向服务器请求，而是直接返回缓存内容。 |
+| &nbsp; &nbsp; &nbsp; &nbsp; -- format | 必选 | String | 指定过期时间的解析格式。分为秒“second”和具体时间格式，如：“20060102150405” |
+| &nbsp; &nbsp; &nbsp; &nbsp;-- expire | 必选 | Object | 指定过期时间的获取位置，标准value结构。 |
+| &nbsp; &nbsp; &nbsp; &nbsp;-- from | 必选 | String | 差异：获取过期时间的位置，是从header域中获取的话，则设置为“header”，如果从body中获取，则设置为“template” |
 
 目前系统并未使用`id`字段定位选择的 HTTPAPI，而是根据指定 HTTPAPI 定义文件的名称。
 
 # API
 用于FLOW和SCHEDULE中
-| 字段           | 用途  | 类型     | 必选 |
-| ------------- | ----- | -------- | ---- |
-| name           | API的名称。| string   | 是   |
-| description    | API的描述。| string   | 否   |
-| command    | API名称。| string   | 是   |
-| private    | 可以用于计算value和覆盖api内部的private。| string   | 否   |
-|resultKey    | 执行结果保存时的索引名称，origin,vars,result,loop为保留值不可使用。      | string   | 否   |
-| args  | api的输入参数,为param结构体|    object[]      |  否    |
-| origin  | 进行tempalte替换时，origin数据，为param结构体|    object[]      |  否    |
+| 字段名称 | 是否必选 | 数据类型 | 描述 |  
+| -- | -- | -- | -- |
+| name | 必选 | String | API的名称。|
+| description | 可选 | String | API的描述。| 
+| command | 必选 | String | API名称。|
+| private | 可选 | String | 可以用于计算value和覆盖api内部的private。|
+| resultKey | 可选 | String | 执行结果保存时的索引名称，origin,vars,result,loop为保留值不可使用。      |
+| args | 可选 | Object[] | api的输入参数,为param结构体|
+| origin | 可选 | Object[] | 进行tempalte替换时，origin数据，为param结构体|
 
 # FLOW
-| 字段           | 用途  | 类型     | 必选 |
-| ------------- | ----- | -------- | ---- |
-| name           | FLOW的名称。| string   | 是   |
-| description    | FLOW的描述。| string   | 否   |
-| private       | API 秘钥文件名用于覆盖内层。 | string   | 否   |
-| steps          | 串行调用API的步骤。为API结构体。   | object[] | 是   |
+| 字段名称 | 是否必选 | 数据类型 | 描述 |  
+| -- | -- | -- | -- |
+| name | 必选 | String | FLOW的名称。|
+| description | 可选 | String | FLOW的描述。| 
+| private | 可选 | String | API 秘钥文件名用于覆盖内层。 |
+| steps  | 必选 | Object[] | 串行调用API的步骤。为API结构体。   |
 
 # SCHEDULE
-| 字段           | 用途  | 类型     | 必选 |
-| ------------- | ----- | -------- | ---- |
-| name            | SCHEDULE 定义的标识。                                         | string   | 是   |
-| description   | SCHEDULE 的描述。                        | string   |  否    |
-| concurrentNum           | 最大允许的并行执行的数量。                               | int   | 否   |
-|          |      |
-| steps    | schedule任务列表。                                object[] |      |
-| --type          | api, loop, switch| string   | 是   |
-| --mode          | 执行模式，normal，concurrent，background三种   | 否   |
-| --private          | API 秘钥文件名用于覆盖内层。   | 否   |
-|--api   | API结构体，type为api时执行。      | object   |  否    |
-|--control   | control结构体，type为loop和switch时执行。      | object   |  否    |
+| 字段名称 | 是否必选 | 数据类型 | 描述 |  
+| -- | -- | -- | -- |
+| name | 必选 | String | SCHEDULE 定义的标识。 |
+| description | 可选 | String | SCHEDULE 的描述。|
+| concurrentNum | 可选 | Int | 最大允许的并行执行的数量。 |
+| steps | -- | Object[] | schedule任务列表。 |
+| &nbsp; &nbsp; &nbsp; &nbsp;-- type | 必选 | String | `api`;</br>`loop`;</br>`switch`| 
+| &nbsp; &nbsp; &nbsp; &nbsp;-- mode | 可选 | String | 执行模式:</br>`normal`;</br>`concurrent`;</br>`background` |
+| &nbsp; &nbsp; &nbsp; &nbsp;-- private | 可选 | String | API 秘钥文件名用于覆盖内层。   | 
+|&nbsp; &nbsp; &nbsp; &nbsp;-- api | 可选 | Object | API结构体，type为api时执行。 |
+|&nbsp; &nbsp; &nbsp; &nbsp;-- control | 可选 | Object | control结构体，type为loop和switch时执行。 |
 
-control结构体定义为
-| 字段           | 用途  | 类型     | 必选 |
-| ------------- | ----- | -------- | ---- |
-| name           | FLOW的名称。| string   | 是   |
-| description    | FLOW的描述。| string   | 否   |
-| private       | API 秘钥文件名用于覆盖内层。 | string   | 否   |
-|--resultKey   |  在API或者FLOW 执行结果对应的名称，在loop时将索引保存在.loop.resultKey,便于后续引用(如{{index .origin.cities .loop.myloop}}), origin,vars,result,loop为保留值不可使用。      | string   |  否    |
-|key   |  switch时为要检查的值，loop时为循环的次数，标准from结构。      | object   |  否    |
-|concurrentNum   |  最大允许的并行执行的数量。      | int   |  否    |
-|concurrentLoopNum   |  最大允许的loop内并行执行的数量。      | int   |  否    |
-| steps    | schedule任务列表。                                object[] |      |
-|          |      |
-|cases   | switch时检查的case。                       | object[]   | 否   |
-| --value   | 上层的key等于本字段则执行tasks。                       | string   | 是   |
-| --concurrentNum   |  最大允许的并行执行的数量。      | int   |  否    |
-| --steps   | 结构同上层的tasks，为tasks的自身嵌套。                       | object[]   | 否   |
-
+control结构体定义为：
+| 字段名称 | 是否必选 | 数据类型 | 描述 |  
+| -- | -- | -- | -- |
+| name | 必选 | String | FLOW的名称。|
+| description | 可选 | String | FLOW的描述。|
+| private | 可选 | String | API 秘钥文件名用于覆盖内层。 |
+| &nbsp; &nbsp; &nbsp; &nbsp;-- resultKey | 可选 | String |  在API或者FLOW 执行结果对应的名称，在loop时将索引保存在.loop.resultKey,便于后续引用(如{{index .origin.cities .loop.myloop}}), origin,vars,result,loop为保留值不可使用。 |
+| key | 可选 | Object |  switch时为要检查的值，loop时为循环的次数，标准from结构。 |
+| concurrentNum | 可选 | Int |  最大允许的并行执行的数量。 |
+| concurrentLoopNum | 可选 | Int |  最大允许的loop内并行执行的数量。 |
+| steps | -- | object[] | schedule任务列表。 | 
+|cases | 可选 | Object[] | switch时检查的case。 | 
+| &nbsp; &nbsp; &nbsp; &nbsp;-- value | 必选 | String | 上层的key等于本字段则执行tasks。 |
+| &nbsp; &nbsp; &nbsp; &nbsp;-- concurrentNum | 可选 | Int |  最大允许的并行执行的数量。 | 
+| &nbsp; &nbsp; &nbsp; &nbsp;-- steps | 可选 | Object[] | 结构同上层的tasks，为tasks的自身嵌套。 | 
+|}|
 # RIGHT
-| 字段    | 用途                                                         | 类型     | 必选 |
-| ------- | ------------------------------------------------------------ | -------- | ---- |
-| type    | 权限文件对应的执行类型，httpapi，flow，schedule              | string   | 是   |
-| right   | 权限类型：public（所有人都允许调用），internal（只允许内部调用，不允许外部调用），whitelist（只有list中的才允许访问），blacklist（非list中的才允许访问） | string   | 是   |
-| list    | user list数组                                                | object[] | 是   |
+| 字段名称 | 是否必选 | 数据类型 | 描述 |  
+| -- | -- | -- | -- |
+| type | 必选 | String | 权限文件对应的执行类型，httpapi，flow，schedule | 
+| right | 必选 | String | 权限类型：</br>`public`（所有人都允许调用）;</br>`internal`（只允许内部调用，不允许外部调用）;</br>`whitelist`（只有list中的才允许访问）;</br>`blacklist`（非list中的才允许访问） |
+| list | 必选 | Object[] | `user list`数组 |
+

--- a/doc/cn/start.md
+++ b/doc/cn/start.md
@@ -1,39 +1,136 @@
-# CONF目录结构
-| 名称                     | 用途                                                         |
-| ----------------------------- | ------------------------------------------------------------ |
+# 1 前言
+本章节主要介绍程序在`Linux`开发环境下的初次启动流程
+
+本章节程序启动后，建立**API网关**进程，API网关进程监听具体调用命令。
+
+|||
+| -- | -- |
+|操作系统|Linux / Windows|
+|软件环境|Golang1.17及以上、GCC9及以上|
+|涉及目录|broker、schema、example|
+
+    注：源码也可在Windows环境进行编译运行，具体步骤见4.1章节注。
+
+# 2 章节涉及目录介绍
+## 2.1 broker文件目录介绍
+
+apihub源码均在`broker`目录下，即针对源码的`build`编译在broker目录下运行。
+
+
+|名称|用途|
+| -- | -- |
+|apis||
+|hub|API信息结构定义|
+|util|工具包|
+|main.go|主程序|
+|go.mod|相关Go包的集合，替换旧的基于`GOPATH`的方法，来指定使用哪些源文件，执行`build`时自动下载相关依赖包到本地指定位置|
+
+## 2.2 schema文件目录介绍
+`schema`目录中存放`json schema`校验文件，`schema`检查`example`文件夹中json文件是否合法，即是否符合API网关格式规范。
+
+schema目录下:
+
+| 名称| 用途|
+| -- | -- |
+| httpapi.json | 定义httpapi的json schema |
+| flow.json | 定义flow的json schema |
+| right.json | 定义right的json schema |
+| schedule.json | 定义schedule的json schema |
+
+## 2.3 example文件目录介绍
+
+`example`目录中存放了规范后的API接口信息，以及API编排后的`flow`，均为`json`格式。
+
+    注：本文中低代码指的是，用户通过配置json文件，编写一个服务的flow，即可低成本，低代码的方式实现API编排功能，而无需理解API网关程序具体工作流程。
+
+API网关与API服务配置文件相互分离。一方面，增加了程序部署的灵活，用户仅需要使用方按照规范提供API接口信息的`json`文件（后续通过mongoDB Web可视化生成和添加API接口信息的json文件），即可针对需求通过低代码的方式设计flow，实现低代码的API编排和调用；另一方面，apihub程序由开发人员维护升级，用户无需关心，降低了用户学习成本。
+
+`example`目录说明：
+|名称| 用途|
+| -- | -- |
 | main.json | 启动文件 |
-| privates                     | 文件夹，存放密码文件                                                 |
-| httpapis                         | 文件夹，存放HTTPAPI定义文件|
-| flows            | 文件夹，存放FLOW定义文件                               |
-| schedules             | 文件夹，存放SCHEDULE定义文件                                         |
-| plugins             | 文件夹，存放动态注册func的.so                                         |
+| privates| 文件夹，存放密码文件|
+| httpapis| 文件夹，存放HTTPAPI定义文件|
+| flows| 文件夹，存放FLOW定义文件|
+| schedules| 文件夹，存放SCHEDULE定义文件|
+| plugins| 文件夹，存放动态注册func的.so|
 | templates | 文件夹，存放html tmpl文件 |
 | rights | 文件夹，存放httpapi，flow和schedule对应的权限列表 |
 
 json文件定义参考[JSON定义](https://github.com/jasony62/tms-go-apihub/blob/main/doc/cn/json.md)
-# SCHEMA目录结构
-位于schema目录下
-| 名称                     | 用途                                                         |
-| ----------------------------- | ------------------------------------------------------------ |
-| httpapi.json | 定义httpapi的json schema |
-# 命令行
-通过`--env`指定使用的环境变量文件(非必须，后续可以通过args里的from env访问)，通过`--base`指定conf文件夹的路径，默认为./conf/。
-因为用例在example下，需要将其软链接或者拷贝到broker/conf下
-启动时读取base路径下的main.json启动，其定义为通用的flow结构，文件里的参数可以写死，也可以从env里获取。
+
+## 3.1 flows、httpapis、schedules
+`broker`目录中`flows`、`httpapis`、`schedules`三个文件夹主要存放API相关文件。
+
+## 3.2 privates
+因为`privates`文件夹存放密码文件，所以没有暴露在git，即git中查找不到为正常现象。
+
+## 3.3 文件关联
+上述主要的三个文件夹`example`、`broker`、`schema`具体工作关系如下:
+
+`broker`目录下编译并执行`tms-go-apihub`文件，`tms-go-apihub`文件通过`schema`文件夹中的校验格式，检查`example`文件夹中json文件的合法性。最后启动API网关的监听服务。
+
+# 4 apihub启动
+## 4.1 build
+源码中已经初始化完成`go.mod`文件，即已经生成依赖包地址。
+
+在`broker`程序源码文件下，执行命令
+```
+go build -o tms-go-apihub
+```
+命令生成名称为`tms-go-apihub`的可执行文件，同时自动下载依赖包到主机。
+    
+    注：若build编译Windows版本，则需要在PowerShell终端窗口执行 
+    go build -o tms-go-apihub.exe 
+    生成exe可执行文件，后续步骤与Linux环境下一致
+## 4.2 run
+由于程序源码的代码预设，需要手动对某些文件进行指定或者软连接，也可根据实际文件位置与运行状态修改代码灵活调整，这里按照源代码预设路径进行操作。
+
+* 方法一：`--env`指定环境变量文件
+通过`--env`指定使用的环境变量文件(非必须，后续可以通过args里的from env访问)，本方法可跳过，直接使用方法二。
+
+* 方法二：`--base`指定conf文件夹的路径
+通过`--base`命令指定`tms-go-apihub`读取的`example`文件夹的路径。
+
+默认`tms-go-apihub`程序需要调用`example`下的API信息，因此需要将`example`文件夹软链接或者拷贝到`broker/conf`目录下(前文中方法二便是通过`--base`命令直接指定文件夹路径，避免了软连接或者拷贝的操作，如果不能理解，直接按照后续命令执行亦可)
+
+在`broker`文件下，具体执行命令如下,通过`--base`命令指定`tms-go-apihub`程序读取的`example`文件夹的路径：
 
 ```
-run go .
+./tms-go-apihub --base ../example/
 ```
 
+程序运行后，正常应处于监听状态
 ```
-run build -o tms-gah-broker
-```
-
-```
-./tms-gah-broker --base ../example/
+[GIN-debug] Listening and serving HTTP on 0.0.0.0:8080
 ```
 
-## docker
+若出现异常现象，需要根据打印提示进行微调，例如：
+* 1.根据提示删除某些无效json文件；
+* 2.若提示端口号被占用，需要修改`/example/main.json`更改端口号
+
+apihub程序启动后，打开新的终端窗口，执行curl命令发送请求，进而获取信息
+```
+curl -i -H "Content-Type: application/json" -d '{"city": "北京"}' "http://localhost:8080/httpapi/amap_district"
+```
+新的终端窗口打印输出如下内容
+```
+ocalhost:8080/httpapi/amap_district"
+HTTP/1.1 403 Forbidden
+Content-Type: application/json; charset=utf-8
+Date: Tue, 19 Jul 2022 09:30:44 GMT
+Content-Length: 4
+```
+`tms-go-apihub`运行窗口打印输出如下内容
+```
+[GIN] 2022/07/19 - 17:30:44 | 403 |      3.2014ms |       127.0.0.1 | POST     "/httpapi/amap_district"
+```
+至此，apihub程序正常启动并工作。
+# 5 补充
+若有响应需求，可进行补充操作，或者功能查找。
+## 5.1 docker
+若在docker环境下运行，执行如下命令。
+
 
 ```
 docker build -t tms/gah-broker .
@@ -53,7 +150,7 @@ docker compose build tms-gah-broker
 docker compose up tms-gah-broker
 ```
 
-## 安装插件
+## 5.2 安装插件
 插件编译不依赖于本代码。
 
 ```


### PR DESCRIPTION
1.修改启动readme，使用者在Linux/Windows安装了go之后，十分钟即可完成对代码的编译和运行，无需过多专业知识，快速展示api网关功能；2.修改json的readme，参考腾讯和华为json定义，对之前json.md文件进行了重新排版和些许修改；3.修改apis的readme，从api编排过程中对api的使用出发，主要介绍了目前20个内部api的使用方式，后续修改持续更新中